### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## package ml - Machine Learning Libraries
-###import "github.com/alonsovidales/go_ml"
+### import "github.com/alonsovidales/go_ml"
 
 [![GoDoc](https://godoc.org/github.com/alonsovidales/go_ml?status.png)](https://godoc.org/github.com/alonsovidales/go_ml)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
